### PR TITLE
Add README, list aggregation, explicit reject (Juniper)

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,0 +1,72 @@
+# filterlist
+
+filterlist is a shell script that generates filter lists for BGP peering
+sessions. Information is gathered by either AS or AS-SET as returned from RADb.
+You may select any whois server that you want, however AS-SET resolution is
+always performed against *whois.radb.net*
+
+**Features:**
+* IPv4 and IPv6 Support
+* AS-SET resolution
+* De-duplication of prefixes
+* Prefix aggregation if the [aggregate](http://freecode.com/projects/aggregate/) command is available
+* Name your filter list
+* Auto-generate part of the filter list name based on the ASN / AS-SET
+
+**Supported filter types:**
+* brocade
+* cisco
+* force10
+* juniper
+* quagga
+* redback
+
+
+## Usage
+
+```bash
+Usage: ./filter.sh [OPTS] AS-SET
+    -t | --type [ juniper | cisco | brocade | force10 | redback | quagga ]
+    -n | --name [ Filter Name ]
+    -g | --gen
+    -a | --aggregate [ Max Len ]
+    -h | --host [ WHOIS server ]
+         --ipv4
+         --ipv6
+```
+
+
+### Examples
+
+**Generate a Juniper IPv4 filter list for AS2**
+```bash
+$ ./filter.sh --type juniper --ipv4 2
+set policy-options policy-statement filter term auto-generated from protocol bgp
+set policy-options policy-statement filter term auto-generated from route-filter 1.1.2.0/24 exact
+set policy-options policy-statement filter term auto-generated from route-filter 2.0.0.0/16 exact
+set policy-options policy-statement filter term auto-generated from route-filter 64.62.96.0/24 exact
+set policy-options policy-statement filter term auto-generated from route-filter 201.62.50.0/24 exact
+set policy-options policy-statement filter term auto-generated from route-filter 201.62.51.0/24 exact
+set policy-options policy-statement filter term auto-generated from route-filter 201.71.32.0/24 exact
+set policy-options policy-statement filter term auto-generated from route-filter 201.71.33.0/24 exact
+set policy-options policy-statement filter term auto-generated from route-filter 201.71.34.0/24 exact
+set policy-options policy-statement filter term auto-generated from route-filter 201.71.35.0/24 exact
+set policy-options policy-statement filter term auto-generated from route-filter 205.143.159.0/24 exact
+set policy-options policy-statement filter term auto-generated then accept
+set policy-options policy-statement filter then reject
+```
+
+**Generate an Aggregated Cisco IPv4 filter list for AS2**
+```bash
+$ ./filter.sh --type juniper -a 24 --ipv4 AS2
+set policy-options policy-statement filter term auto-generated from protocol bgp
+set policy-options policy-statement filter term auto-generated from route-filter 1.1.2.0/24 upto /24
+set policy-options policy-statement filter term auto-generated from route-filter 2.0.0.0/16 upto /24
+set policy-options policy-statement filter term auto-generated from route-filter 64.62.96.0/24 upto /24
+set policy-options policy-statement filter term auto-generated from route-filter 201.62.50.0/23 upto /24
+set policy-options policy-statement filter term auto-generated from route-filter 201.71.32.0/22 upto /24
+set policy-options policy-statement filter term auto-generated from route-filter 205.143.159.0/24 upto /24
+set policy-options policy-statement filter term auto-generated then accept
+set policy-options policy-statement filter then reject
+```
+

--- a/filter.sh
+++ b/filter.sh
@@ -178,7 +178,7 @@ done
 # Tell the Juniper router to accept those prefixes
 if [[ "$TYPE" == "juniper" ]]
 then
-	echo "set policy-options policy-statement $FILTERNAME term auto-generated then accept"
+	echo "set policy-options policy-statement $FILTERNAME term $TERMNAME then accept"
 	echo "set policy-options policy-statement $FILTERNAME then reject"
 fi
 

--- a/filter.sh
+++ b/filter.sh
@@ -124,6 +124,11 @@ then
 	echo "ip prefix-list $FILTERNAME"
 fi
 
+if [[ "$TYPE" == "juniper" ]]
+then
+	echo "set policy-options policy-statement $FILTERNAME term $TERMNAME from protocol bgp"
+fi
+
 # Format the output nicely
 for i in $IP_LIST
 do
@@ -174,5 +179,6 @@ done
 if [[ "$TYPE" == "juniper" ]]
 then
 	echo "set policy-options policy-statement $FILTERNAME term auto-generated then accept"
+	echo "set policy-options policy-statement $FILTERNAME then reject"
 fi
 

--- a/filter.sh
+++ b/filter.sh
@@ -25,6 +25,7 @@ usage()
 	echo "Usage: $0 [OPTS] AS-SET"
 	echo "    -t | --type [ juniper | cisco | brocade | force10 | redback | quagga ]"
 	echo "    -n | --name [ Filter Name ]"
+	echo "    -g | --gen"
 	echo "    -h | --host [ WHOIS server ]"
 	echo "         --ipv4"
 	echo "         --ipv6"
@@ -32,6 +33,8 @@ usage()
 
 # Initialise some variables, to make it safe to use
 FILTERNAME="filter"
+FILTERNAMEGEN=0
+TERMNAME="auto-generated"
 INC=10
 IP_LIST=""
 WHOISSERVER="whois.radb.net"
@@ -47,6 +50,10 @@ while [[ $1 = -* ]]; do
 		-n|--name)
 			FILTERNAME="$2"
 			shift 2
+			;;
+		-g|--gen)
+			FILTERNAMEGEN=1
+			shift
 			;;
 		-h|--host)
 			WHOISSERVER="$2"
@@ -80,6 +87,11 @@ fi
 
 # Do we have an AS-SET or an ASN?
 IS_SET=$(echo $1 | cut -c3 | grep -)
+
+if [[ 1 == $FILTERNAMEGEN ]]
+then
+	FILTERNAME="${1}-${FILTERNAME}"
+fi
 
 # If we've got an AS-SET, use the handy !i and ,1 commands on RADB
 if [[ "-" == "$IS_SET" ]]
@@ -117,7 +129,7 @@ for i in $IP_LIST
 do
 	case "$TYPE" in
 		juniper)
-			echo "set policy-options policy-statement $FILTERNAME term auto-generated from route-filter $i exact"
+			echo "set policy-options policy-statement $FILTERNAME term $TERMNAME from route-filter $i exact"
 			;;
 		cisco)
 			if [[ "$IP_VERSION" == "4" ]]


### PR DESCRIPTION
I found this script to be extremely useful, thanks a lot for opening it up!  I've added a brief README with examples, and a few functional changes.

* Add an explicit 'then reject' for the Juniper filter generation
* Add an option to aggregate the prefixes fetched, and allow prefixes from the aggregate upto the specified CIDR mask (currently only used with Juniper filters)
* Ability to auto-generate the filter output name based on the ASN / AS-SET name, then appending the specified filter name as well. This could be extended to allow prefixing the name, or dropping it all together.

All of these changes have been tested, and used to generate filters that have been put into production.